### PR TITLE
Change Jekyll theme to 'time-machine'

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,4 @@
-theme: jekyll-theme-hacker
+theme: jekyll-theme-time-machine
 title: GPT-4 Chat Session to Markdown Converter
 author: Jegors Čemisovs
 email: jegors.cemisovs@gmail.com


### PR DESCRIPTION
Changed the Jekyll theme from 'hacker' to 'time-machine' in the '_config.yml' file, as this new theme better fits the aesthetic and functional needs of the 'GPT-4 Chat Session to Markdown Converter' project.