### PR TITLE
Correct baseurl configuration in Jekyll config file

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -5,7 +5,7 @@ description: >
   GPT-4 Chat Session to Markdown Converter: A handy command-line tool that uses JQ to convert GPT-4 chat session JSON data into a more readable and visually appealing Markdown format.
 
 url: https://rabestro.github.io/gpt4-chat-session-to-markdown/
-baseurl: /gpt4-chat-session-to-markdown
+#baseurl: /gpt4-chat-session-to-markdown
 repository: rabestro/gpt4-chat-session-to-markdown
 
 author:


### PR DESCRIPTION
The baseurl was commented out to fix potential issues with the generation of relative URLs inside the Jekyll project, which was previously leading to incorrect paths on the deployed website. Now the baseurl element will be automatically fetched from the site's default settings.