### PR TITLE
Implement GitHub Pages example documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,5 +26,15 @@ For an example of input JSON data and the corresponding Markdown output, please 
 - [Sample Input JSON Data](sample-input.json)
 - [Sample Output Markdown](sample-output.md)
 
+## Example Usage
+The following is an example of how this script can be used to convert GPT-4 chat session JSON data into Markdown format:
+
+```bash
+cd docs
+../gpt4-session-to-md.jq github-pages.json > github-pages.md
+```
+
+- [Sample Session with AI](github-pages.md)
+
 ## License
 This project is open-source and released under the [MIT License](LICENSE).

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -5,7 +5,6 @@ description: >
   GPT-4 Chat Session to Markdown Converter: A handy command-line tool that uses JQ to convert GPT-4 chat session JSON data into a more readable and visually appealing Markdown format.
 
 url: https://rabestro.github.io/gpt4-chat-session-to-markdown/
-#baseurl: /gpt4-chat-session-to-markdown
 repository: rabestro/gpt4-chat-session-to-markdown
 
 author:

--- a/docs/github-pages.json
+++ b/docs/github-pages.json
@@ -1,0 +1,112 @@
+{
+  "version": 4,
+  "history": [
+    {
+      "id": "28ec4495-44b9-4328-bd4d-855059f39af8",
+      "name": "GitHub Pages",
+      "model": {
+        "id": "gpt-4",
+        "name": "GPT-4",
+        "type": "model",
+        "maxLength": 24000,
+        "requestLimit": 6000
+      },
+      "prompt": "Act as an experienced DevOps knowledgeable on GitHub and Jekyll. Your task is to answer questions about setting up a GitHub Pages site with Jekyll. When responding, please provide links to official documentation or sources of information.",
+      "temperature": 0.1,
+      "folderId": null,
+      "messages": [
+        {
+          "role": "user",
+          "content": "Hey!"
+        },
+        {
+          "content": "Hello! How can I help you with GitHub Pages or Jekyll? If you have any questions or need guidance, feel free to ask.\n",
+          "model": {
+            "id": "gpt-4",
+            "name": "GPT-4"
+          },
+          "role": "assistant"
+        },
+        {
+          "role": "user",
+          "content": " What type of information I can specify in _config.yml?"
+        },
+        {
+          "content": "`_config.yml` is the configuration file for your Jekyll site and is used to store various settings related to your site. Some of the things you can configure in `_config.yml` include:\n\n1. Site settings: Title, description, and URL of your website.\n2. Author information: Name, email, and social media handles.\n3. Themes: The Jekyll theme you want to use for your site.\n4. Default settings for posts, pages, and other content on your site.\n5. Build settings: Custom plugins, source and destination directories, or other Jekyll build options.\n\nHere's an example of a `_config.yml` file structure:\n\n```yaml\ntitle: \"Your Site Title\"\ndescription: \"A description of your site\"\nurl: \"https://example.com\"\nbaseurl: \"/\"\n\nauthor:\n  name: \"Your Name\"\n  email: \"your_email@example.com\"\n\ntheme: \"minima\"\n\ndefaults:\n  - scope:\n      path: \"\"\n      type: \"posts\"\n    values:\n      layout: \"post\"\n      author: \"Your Name\"\n\nplugins:\n  - jekyll-feed\n```\n\nYou can find more detailed information in the official Jekyll documentation on configuration:\n[https://jekyllrb.com/docs/configuration/](https://jekyllrb.com/docs/configuration/)",
+          "model": {
+            "id": "gpt-4",
+            "name": "GPT-4"
+          },
+          "role": "assistant"
+        },
+        {
+          "role": "user",
+          "content": "Please count all themes available for github pages"
+        },
+        {
+          "content": "GitHub Pages officially supports a limited number of themes; however, you are free to use any third-party Jekyll themes or create your own custom theme for your GitHub Pages site.\n\nAs of now, there are 13 officially supported Jekyll themes for GitHub Pages:\n\n1. Cayman: [jekyll-theme-cayman](https://github.com/pages-themes/cayman)\n2. Dinky: [jekyll-theme-dinky](https://github.com/pages-themes/dinky)\n3. Hacker: [jekyll-theme-hacker](https://github.com/pages-themes/hacker)\n4. Leap Day: [jekyll-theme-leap-day](https://github.com/pages-themes/leap-day)\n5. Merlot: [jekyll-theme-merlot](https://github.com/pages-themes/merlot)\n6. Midnight: [jekyll-theme-midnight](https://github.com/pages-themes/midnight)\n7. Minimal: [jekyll-theme-minimal](https://github.com/pages-themes/minimal)\n8. Minima (Default): [jekyll-minima](https://github.com/jekyll/minima)\n9. Modernist: [jekyll-theme-modernist](https://github.com/pages-themes/modernist)\n10. Slate: [jekyll-theme-slate](https://github.com/pages-themes/slate)\n11. Tactile: [jekyll-theme-tactile](https://github.com/pages-themes/tactile)\n12. Time Machine: [jekyll-theme-time-machine](https://github.com/pages-themes/time-machine)\n13. Architect: [jekyll-theme-architect](https://github.com/pages-themes/architect)\n\nTo apply one of these themes, you can add the theme name to your `_config.yml` file, like this:\n\n```yaml\ntheme: jekyll-theme-cayman\n```\n\nFor instructions on setting up your GitHub Pages site with a custom or third-party Jekyll theme, please refer to the official GitHub Pages documentation:\n[https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/adding-a-theme-to-your-github-pages-site](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/adding-a-theme-to-your-github-pages-site)",
+          "model": {
+            "id": "gpt-4",
+            "name": "GPT-4"
+          },
+          "role": "assistant"
+        },
+        {
+          "role": "user",
+          "content": "If I use jekyll-theme-minimal what options are available for _config.yml?"
+        },
+        {
+          "content": "When using the `jekyll-theme-minimal`, you can configure several options in your `_config.yml` file. These options are specific to the theme and are separate from the default Jekyll options.\n\nHere are the options available for the Minimal theme:\n\n1. `google_analytics`: Google Analytics tracking ID (e.g., `UA-00000000-0`).\n\n2. `title`: The title of your site, which appears in the header navigation.\n\n3. `description`: A brief description of your site that appears below the title in the header navigation.\n\n4. `show_downloads`: If set to `true`, download links for ZIP and tarball archives will be displayed in the footer section. The default value is `true`.\n\nExample `_config.yml` configuration for the Minimal theme:\n\n```yaml\ntitle: \"My Minimal Site\"\ndescription: \"A clean and simple Jekyll theme\"\ntheme: \"jekyll-theme-minimal\"\ngoogle_analytics: \"UA-00000000-0\"\nshow_downloads: true\n```\n\nYou can also customize the theme's style by overriding the default CSS. You can do this by creating a file called `assets/css/style.scss` in your site's root directory with the following content:\n\n```scss\n---\n---\n@import \"{{ site.theme }}\";\n// Your custom styles go here\n```\n\nMore information about the Minimal theme can be found in the GitHub repository:\n[https://github.com/pages-themes/minimal](https://github.com/pages-themes/minimal)\n\nAdditionally, you can still configure the standard Jekyll options, like `author`, `url`, `baseurl`, and others, as described in the Jekyll documentation:\n[https://jekyllrb.com/docs/configuration/](https://jekyllrb.com/docs/configuration/)",
+          "model": {
+            "id": "gpt-4",
+            "name": "GPT-4"
+          },
+          "role": "assistant"
+        },
+        {
+          "role": "user",
+          "content": "Does this file has `repository` option?"
+        },
+        {
+          "content": "Yes, the Minimal theme does support the `repository` option in the `_config.yml` file. The `repository` option is used to specify your GitHub repository's path as a string, using the format `username/repo-name`. This is particularly useful when you want to show the \"Fork me on GitHub\" ribbon or a \"View on GitHub\" link.\n\nHere's an example of how you can include the `repository` option in your `_config.yml` file:\n\n```yaml\ntitle: \"My Minimal Site\"\ndescription: \"A clean and simple Jekyll theme\"\ntheme: \"jekyll-theme-minimal\"\nrepository: \"yourusername/your-repo-name\"\n```\n\nBy specifying the `repository`, you can then use the `site.github` metadata in your theme's templates to display information related to the repository, like linking to the repository home page or showing download links. This is facilitated by the `jekyll-github-metadata` plugin which is already enabled by default on GitHub Pages.\n\nFor more details on using repository metadata, you can refer to the `jekyll-github-metadata` plugin documentation:\n[https://jekyll.github.io/github-metadata/](https://jekyll.github.io/github-metadata/)",
+          "model": {
+            "id": "gpt-4",
+            "name": "GPT-4"
+          },
+          "role": "assistant"
+        },
+        {
+          "role": "user",
+          "content": "What sub-options has `author`?"
+        },
+        {
+          "content": "The `author` setting in the `_config.yml` file can have various sub-options to provide more information about the author. These sub-options can then be accessed through the `site.author` object in your Jekyll templates. Some of the common sub-options include:\n\n1. `name`: The author's full name.\n2. `email`: The author's email address.\n3. `bio`: A short bio of the author.\n4. `avatar`: A URL to the author's avatar image.\n5. `web`: The author's personal website URL.\n6. `location`: The author's location.\n7. `social`: Social media profiles with the platform as the key and the URL or username as the value.\n\nHere's an example of how you can define the `author` with various sub-options in the `_config.yml` file:\n\n```yaml\nauthor:\n  name: \"John Doe\"\n  email: \"john.doe@example.com\"\n  bio: \"A software developer and blogger\"\n  avatar: \"https://example.com/images/avatar.jpg\"\n  web: \"https://www.johndoe.com\"\n  location: \"New York\"\n  social:\n    github: \"johndoe\"\n    twitter: \"johndoe\"\n    linkedin: \"https://www.linkedin.com/in/johndoe/\"\n```\n\nThese sub-options can then be used in your Jekyll theme templates using Liquid tags. For example:\n\n```\n{{ site.author.name }}\n{{ site.author.email }}\n{{ site.author.bio }}\n```\n\nNote that these sub-options are common and not specifically tied to any theme. They may or may not be utilized depending on the theme or template you're using. You can adjust your templates or choose a theme that supports these sub-options to display this information on your site.",
+          "model": {
+            "id": "gpt-4",
+            "name": "GPT-4"
+          },
+          "role": "assistant"
+        },
+        {
+          "role": "user",
+          "content": "It's all for today. I appreciate your help!"
+        },
+        {
+          "content": "You're welcome! I'm glad I could help. If you have any more questions or need assistance in the future, feel free to ask. Have a great day!\n",
+          "model": {
+            "id": "gpt-4",
+            "name": "GPT-4"
+          },
+          "role": "assistant"
+        }
+      ],
+      "replay": {
+        "isReplay": false,
+        "replayUserMessagesStack": [],
+        "activeReplayIndex": 0
+      },
+      "selectedAddons": []
+    }
+  ],
+  "folders": []
+}

--- a/docs/github-pages.md
+++ b/docs/github-pages.md
@@ -1,0 +1,181 @@
+# GitHub Pages
+
+<details>
+<summary>Model: GPT-4, Temperature: 0.1</summary>
+Act as an experienced DevOps knowledgeable on GitHub and Jekyll. Your task is to answer questions about setting up a GitHub Pages site with Jekyll. When responding, please provide links to official documentation or sources of information.
+</details>
+
+
+👤 Hey!
+
+🤖 Hello! How can I help you with GitHub Pages or Jekyll? If you have any questions or need guidance, feel free to ask.
+
+
+👤  What type of information I can specify in _config.yml?
+
+🤖 `_config.yml` is the configuration file for your Jekyll site and is used to store various settings related to your site. Some of the things you can configure in `_config.yml` include:
+
+1. Site settings: Title, description, and URL of your website.
+2. Author information: Name, email, and social media handles.
+3. Themes: The Jekyll theme you want to use for your site.
+4. Default settings for posts, pages, and other content on your site.
+5. Build settings: Custom plugins, source and destination directories, or other Jekyll build options.
+
+Here's an example of a `_config.yml` file structure:
+
+```yaml
+title: "Your Site Title"
+description: "A description of your site"
+url: "https://example.com"
+baseurl: "/"
+
+author:
+  name: "Your Name"
+  email: "your_email@example.com"
+
+theme: "minima"
+
+defaults:
+  - scope:
+      path: ""
+      type: "posts"
+    values:
+      layout: "post"
+      author: "Your Name"
+
+plugins:
+  - jekyll-feed
+```
+
+You can find more detailed information in the official Jekyll documentation on configuration:
+[https://jekyllrb.com/docs/configuration/](https://jekyllrb.com/docs/configuration/)
+
+👤 Please count all themes available for github pages
+
+🤖 GitHub Pages officially supports a limited number of themes; however, you are free to use any third-party Jekyll themes or create your own custom theme for your GitHub Pages site.
+
+As of now, there are 13 officially supported Jekyll themes for GitHub Pages:
+
+1. Cayman: [jekyll-theme-cayman](https://github.com/pages-themes/cayman)
+2. Dinky: [jekyll-theme-dinky](https://github.com/pages-themes/dinky)
+3. Hacker: [jekyll-theme-hacker](https://github.com/pages-themes/hacker)
+4. Leap Day: [jekyll-theme-leap-day](https://github.com/pages-themes/leap-day)
+5. Merlot: [jekyll-theme-merlot](https://github.com/pages-themes/merlot)
+6. Midnight: [jekyll-theme-midnight](https://github.com/pages-themes/midnight)
+7. Minimal: [jekyll-theme-minimal](https://github.com/pages-themes/minimal)
+8. Minima (Default): [jekyll-minima](https://github.com/jekyll/minima)
+9. Modernist: [jekyll-theme-modernist](https://github.com/pages-themes/modernist)
+10. Slate: [jekyll-theme-slate](https://github.com/pages-themes/slate)
+11. Tactile: [jekyll-theme-tactile](https://github.com/pages-themes/tactile)
+12. Time Machine: [jekyll-theme-time-machine](https://github.com/pages-themes/time-machine)
+13. Architect: [jekyll-theme-architect](https://github.com/pages-themes/architect)
+
+To apply one of these themes, you can add the theme name to your `_config.yml` file, like this:
+
+```yaml
+theme: jekyll-theme-cayman
+```
+
+For instructions on setting up your GitHub Pages site with a custom or third-party Jekyll theme, please refer to the official GitHub Pages documentation:
+[https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/adding-a-theme-to-your-github-pages-site](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/adding-a-theme-to-your-github-pages-site)
+
+👤 If I use jekyll-theme-minimal what options are available for _config.yml?
+
+🤖 When using the `jekyll-theme-minimal`, you can configure several options in your `_config.yml` file. These options are specific to the theme and are separate from the default Jekyll options.
+
+Here are the options available for the Minimal theme:
+
+1. `google_analytics`: Google Analytics tracking ID (e.g., `UA-00000000-0`).
+
+2. `title`: The title of your site, which appears in the header navigation.
+
+3. `description`: A brief description of your site that appears below the title in the header navigation.
+
+4. `show_downloads`: If set to `true`, download links for ZIP and tarball archives will be displayed in the footer section. The default value is `true`.
+
+Example `_config.yml` configuration for the Minimal theme:
+
+```yaml
+title: "My Minimal Site"
+description: "A clean and simple Jekyll theme"
+theme: "jekyll-theme-minimal"
+google_analytics: "UA-00000000-0"
+show_downloads: true
+```
+
+You can also customize the theme's style by overriding the default CSS. You can do this by creating a file called `assets/css/style.scss` in your site's root directory with the following content:
+
+```scss
+---
+---
+@import "{{ site.theme }}";
+// Your custom styles go here
+```
+
+More information about the Minimal theme can be found in the GitHub repository:
+[https://github.com/pages-themes/minimal](https://github.com/pages-themes/minimal)
+
+Additionally, you can still configure the standard Jekyll options, like `author`, `url`, `baseurl`, and others, as described in the Jekyll documentation:
+[https://jekyllrb.com/docs/configuration/](https://jekyllrb.com/docs/configuration/)
+
+👤 Does this file has `repository` option?
+
+🤖 Yes, the Minimal theme does support the `repository` option in the `_config.yml` file. The `repository` option is used to specify your GitHub repository's path as a string, using the format `username/repo-name`. This is particularly useful when you want to show the "Fork me on GitHub" ribbon or a "View on GitHub" link.
+
+Here's an example of how you can include the `repository` option in your `_config.yml` file:
+
+```yaml
+title: "My Minimal Site"
+description: "A clean and simple Jekyll theme"
+theme: "jekyll-theme-minimal"
+repository: "yourusername/your-repo-name"
+```
+
+By specifying the `repository`, you can then use the `site.github` metadata in your theme's templates to display information related to the repository, like linking to the repository home page or showing download links. This is facilitated by the `jekyll-github-metadata` plugin which is already enabled by default on GitHub Pages.
+
+For more details on using repository metadata, you can refer to the `jekyll-github-metadata` plugin documentation:
+[https://jekyll.github.io/github-metadata/](https://jekyll.github.io/github-metadata/)
+
+👤 What sub-options has `author`?
+
+🤖 The `author` setting in the `_config.yml` file can have various sub-options to provide more information about the author. These sub-options can then be accessed through the `site.author` object in your Jekyll templates. Some of the common sub-options include:
+
+1. `name`: The author's full name.
+2. `email`: The author's email address.
+3. `bio`: A short bio of the author.
+4. `avatar`: A URL to the author's avatar image.
+5. `web`: The author's personal website URL.
+6. `location`: The author's location.
+7. `social`: Social media profiles with the platform as the key and the URL or username as the value.
+
+Here's an example of how you can define the `author` with various sub-options in the `_config.yml` file:
+
+```yaml
+author:
+  name: "John Doe"
+  email: "john.doe@example.com"
+  bio: "A software developer and blogger"
+  avatar: "https://example.com/images/avatar.jpg"
+  web: "https://www.johndoe.com"
+  location: "New York"
+  social:
+    github: "johndoe"
+    twitter: "johndoe"
+    linkedin: "https://www.linkedin.com/in/johndoe/"
+```
+
+These sub-options can then be used in your Jekyll theme templates using Liquid tags. For example:
+
+```
+{{ site.author.name }}
+{{ site.author.email }}
+{{ site.author.bio }}
+```
+
+Note that these sub-options are common and not specifically tied to any theme. They may or may not be utilized depending on the theme or template you're using. You can adjust your templates or choose a theme that supports these sub-options to display this information on your site.
+
+👤 It's all for today. I appreciate your help!
+
+🤖 You're welcome! I'm glad I could help. If you have any more questions or need assistance in the future, feel free to ask. Have a great day!
+
+

--- a/gpt4-session-to-md.jq
+++ b/gpt4-session-to-md.jq
@@ -13,7 +13,7 @@
 "<details>\n" +
 "<summary>Model: \(.model.name), Temperature: \(.temperature)</summary>\n" +
 "\(.prompt)\n" +
-"</details>\n\n") + (
+"</details>\n\n\n") + (
   .messages | map(
     (
       if .role == "user" then "👤" else "🤖" end


### PR DESCRIPTION
Created an example usage of converting GPT-4 chat session JSON data to Markdown with JQ. This includes example JSON data for a GitHub Pages related QA session and the successfully generated Markdown from that. Fixes were also made for the Jekyll config file for generating correct URLs.

This enhancement serves as a live illustration for users on how to utilize the JSON to Markdown converter. Defining such use-cases guides users to understand the functionality and implementation and hence, increases user accessibility of the tool. It also fixes the URL path generation in the Jekyll project, ensuring the right navigation on the deployed website.