### PR TITLE
Remove baseurl from _config.yml and improve documentation

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -5,7 +5,6 @@ description: >
   GPT-4 Chat Session to Markdown Converter: A handy command-line tool that uses JQ to convert GPT-4 chat session JSON data into a more readable and visually appealing Markdown format.
 
 url: https://rabestro.github.io/gpt4-session-to-markdown/
-baseurl: /gpt4-session-to-markdown
 repository: rabestro/gpt4-session-to-markdown
 
 author:


### PR DESCRIPTION
Removed the 'baseurl' line from '_config.yml' as it was redundant and was not needed for the project's configuration. The intention is to avoid any confusion and to make the configuration file cleaner and easier to understand.

In addition, updated references to the repository's URL to reflect a recent change in the project's name. The update ensures consistency and that all links will work correctly.