### PR TITLE
Update post date format in docs

### DIFF
--- a/docs/_posts/2023-08-24-binary-tree-maximum-path-sum.md
+++ b/docs/_posts/2023-08-24-binary-tree-maximum-path-sum.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Binary Tree Maximum Path Sum"
-date: 2023-08-24
+date: 2023-08-24 00:00:00 -0000
 categories: [ai, unit test, java, gpt-4]
 ---
 


### PR DESCRIPTION
Changed the date format in "Binary Tree Maximum Path Sum" post to include time with timezone in the docs/_posts/2023-08-24-binary-tree-maximum-path-sum.md. This change is to ensure consistency across all documents and also clarity for readers located in different timezones.