### PR TITLE
Add session listing to README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -38,3 +38,12 @@ cd docs
 
 ## License
 This project is open-source and released under the [MIT License](LICENSE).
+
+## Some other ChatGPT-4 sessions
+
+{% for post in site.posts %}
+  <li>
+    <a href="{{ post.url }}">{{ post.title }}</a>
+    <small>{{ post.date | date: "%B %d, %Y" }}</small>
+  </li>
+{% endfor %}

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,7 +1,7 @@
 theme: jekyll-theme-minimal
 
 title: Chat Session to Markdown
-description: >
+description: >-
   GPT-4 Chat Session to Markdown Converter: A handy command-line tool that uses JQ to convert GPT-4 chat session JSON data into a more readable and visually appealing Markdown format.
 
 author:
@@ -19,3 +19,7 @@ author:
 # social links
 twitter_username: rabestro
 github_username:  rabestro
+
+# Permalinks
+permalink:      /:year-:month-:day/:title
+paginate:       5

--- a/gpt4-session-to-md.jq
+++ b/gpt4-session-to-md.jq
@@ -12,7 +12,7 @@
 "<details>\n" +
 "<summary>Model: \(.model.name), Temperature: \(.temperature)</summary>\n" +
 "\(.prompt)\n" +
-"</details>\n\n___\n") + (
+"</details>\n\n___\n\n") + (
   .messages | map(
     (
       if .role == "user" then "👤" else "🤖" end


### PR DESCRIPTION
README.md has been updated to include a list of all other ChatGPT-4 sessions. The sessions are organized as links with their associated post date for easier navigation and structured representation. This improves user engagement by providing direct and quick access to different ChatGPT-4 sessions.